### PR TITLE
Expect s2i-custom-notebook image to be used

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -48,3 +48,5 @@ For a detailed guide on how to adjust your notebooks etc, please consult [docume
      --dry-run -o yaml |
    sops --input-type=yaml --output-type=yaml -e /dev/stdin > ceph-creds.yaml
    ```
+
+Note: You can use the S2I image, that was built by [s2i-custom-notebook](https://github.com/AICoE/s2i-custom-notebook) for this automation. This image is expected to be used by default, therefore the `workingDir` is adjusted to `/opt/app-root/backup`. Please change or remove this settings in case you plan on using different image.

--- a/manifests/cron-workflow.yml
+++ b/manifests/cron-workflow.yml
@@ -68,6 +68,8 @@ spec:
             - --config
             - .jupyter/jupyter_nbconvert_config.py
             - "notebooks/{{inputs.parameters.notebook}}"
+          # If using different image than built by https://github.com/AICoE/s2i-custom-notebook, please change or remote the workingDir settings
+          workingDir: /opt/app-root/backup
           volumeMounts:
             - name: local-data-storage
               mountPath: /mnt/data


### PR DESCRIPTION
Unify the Argo automation with [`s2i-custom-notebook`](https://github.com/AICoE/s2i-custom-notebook) - setting the working dir does the trick.