### PR TITLE
Match the managed-by label with LDAP and reflect the label structure better

### DIFF
--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 commonLabels:
   app.kubernetes.io/name: aiops-analytics
   app.kubernetes.io/component: <CHANGE_ME>
-  app.kubernetes.io/managed-by: aicoe-aiops-argocd
+  app.kubernetes.io/managed-by: aicoe-aiops-devops-argocd
 
 resources:
   - imagestream.yaml

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -2,8 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 commonLabels:
-  app.kubernetes.io/name: aiops-analytics
+  app.kubernetes.io/name: <CHANGE_ME>
   app.kubernetes.io/component: <CHANGE_ME>
+  app.kubernetes.io/part-of: aiops-analytics
   app.kubernetes.io/managed-by: aicoe-aiops-devops-argocd
 
 resources:


### PR DESCRIPTION
Maybe a nitpick, but I think it may be nice to have the managed-by label matching our LDAP group [aicoe-aiops-devops](https://rover.redhat.com/groups/group/aicoe-aiops-devops). IT was descriptive enough already, but... why not to change it... :smile: 

Also the structure didn't follow the recommendations precisely enough: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ This should be better.