### PR TITLE
Srcops update

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -2,3 +2,15 @@
 # Example `.aicoe-ci.yaml` with a full list of config options is available here: https://github.com/AICoE/aicoe-ci/blob/master/docs/.aicoe-ci.yaml
 check:
   - thoth-precommit
+  # Uncomment following line to build a public image of this repo
+  # - thoth-build
+
+# Uncomment following lines to build a public image of this repo
+# build:
+#   build-stratergy: Source
+#   build_source_script: "image:///opt/app-root/builder"
+#   base-image: quay.io/thoth-station/s2i-custom-notebook:latest
+#   registry: quay.io
+#   registry-org: aicoe
+#   registry-project: <CHANGE-ME>
+#   registry-secret: aicoe-pusher-secret

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @durandom @tumido

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/major-release.md
+++ b/.github/ISSUE_TEMPLATE/major-release.md
@@ -1,0 +1,11 @@
+---
+name: Major release
+about: Create a new major release
+title: New major release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new major release, please.

--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -1,0 +1,11 @@
+---
+name: Minor release
+about: Create a new minor release
+title: New minor release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new minor release, please.

--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -1,0 +1,11 @@
+---
+name: Patch release
+about: Create a new patch release
+title: New patch release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new patch release, please.

--- a/.github/ISSUE_TEMPLATE/redeliver_container_image.md
+++ b/.github/ISSUE_TEMPLATE/redeliver_container_image.md
@@ -1,0 +1,13 @@
+---
+name: Deliver Container Image
+about: build a git tag and push it as a container image to quay
+title: Deliver Container Image
+assignees: sesheta
+labels: bot
+---
+
+Hey, AICoE-CI!
+
+Please build and deliver the following git tag:
+
+Tag: x.y.z

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Related Issues and Dependencies
+
+…
+
+## This introduces a breaking change
+
+- [ ] Yes
+- [ ] No
+
+<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
+
+## This Pull Request implements
+
+… Explain your changes.
+
+## Description
+
+<!--- Describe your changes in detail -->


### PR DESCRIPTION
Similar to: https://github.com/aicoe-aiops/categorical-encoding/pull/4

I've noticed we're missing the issue and PR templates here. They are beneficial, since they allow us to publish images (kick off the AICoE-CI release pipelines) from UI by filing an issue - making releases trackable. This change should make it much easier to release images.

Also a template "commented out" `.aicoe-ci.yaml` section was added - this allows for publicly available builds into quay. Once a repo goes public, simply uncomment this section, invite sesheta to your repo (or add sourceops team) and it's all set.