### PR TITLE
Move version to a variable to make AICoE-CI happy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from setuptools import find_packages, setup
 
+__version__ = "0.1.0"
+
 setup(
     name="src",
     packages=find_packages(),
-    version="0.1.0",
+    version=__version__,
     description="template for the team to use",
     author="aicoe-aiops",
     license="",


### PR DESCRIPTION
## Related Issues and Dependencies

Mirroring changes from https://github.com/aicoe-aiops/categorical-encoding/pull/7

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

AICoE-CI requires a version to be specified in a variable instead of just a property of the setup. This change allows Kebechet to really go and bump the version, so the release process can be successful.

Reference: [`kebechet/managers/version`](https://github.com/thoth-station/kebechet/blob/609735637db076304fbcf8157a51751eb66fdbcd/kebechet/managers/version/version.py#L135)