### PR TITLE
Fix JH image build.

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -8,7 +8,7 @@ check:
 # Uncomment following lines to build a public image of this repo
 # build:
 #   build-stratergy: Source
-#   build_source_script: "image:///opt/app-root/builder"
+#   build-source-script: "image:///opt/app-root/builder"
 #   base-image: quay.io/thoth-station/s2i-custom-notebook:latest
 #   registry: quay.io
 #   registry-org: aicoe


### PR DESCRIPTION
## Description

Fix image build for Jupyterhub by using the `build-source-script` key in .aicoe-ci.yaml

see operate-first/odh-moc-support#17 for details

## This introduces a breaking change

- [ ] Yes
- [X] No

