### PR TITLE
fix: Remove pre commit hook for large files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: name-tests-test
-      - id: check-added-large-files
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first


### PR DESCRIPTION
## Related Issues and Dependencies

By @MichaelClifford's request.

This hook causes troubles, since Jupyter Notebooks can be quite big, this PR removes the particular check from our pre commit. Unfortunately, there's no way to exclude certain filetypes from this check right now. We can raise the size limit though.

https://github.com/pre-commit/pre-commit-hooks#check-added-large-files